### PR TITLE
BestFit boundary update and -env.yml file dependency change for Issues #79 #78

### DIFF
--- a/build-env.yml
+++ b/build-env.yml
@@ -5,11 +5,10 @@ channels:
 dependencies:
   - codecov
   - gcc
-  - gfortran
   - demes
-  - dill==0.3.4
+  - dill
   - matplotlib
-  - ndcctools==7.4.3
+  - ndcctools
   - nlopt
   - numpy
   - pip

--- a/conda-cpu-env.yml
+++ b/conda-cpu-env.yml
@@ -7,9 +7,9 @@ dependencies:
   - gfortran
   - gxx==11.3
   - demes
-  - dill==0.3.4
+  - dill
   - matplotlib
-  - ndcctools==7.4.3
+  - ndcctools
   - nlopt
   - numpy
   - pip

--- a/conda-gpu-env.yml
+++ b/conda-gpu-env.yml
@@ -9,9 +9,9 @@ dependencies:
   - gfortran
   - gxx==11.3
   - demes
-  - dill==0.3.4
+  - dill
   - matplotlib
-  - ndcctools==7.4.3
+  - ndcctools
   - nlopt
   - numpy
   - pip

--- a/dadi_cli/__main__.py
+++ b/dadi_cli/__main__.py
@@ -1612,7 +1612,20 @@ def dadi_cli_parser():
         dest="input_prefix",
         help='Prefix for input files, which is named <input-prefix ending with ".InferDM">.opts.<N> or <input-prefix ending with "InferDFE">.opts.<N>, containing the inferred demographic or DFE parameters.',
     )
-    add_bounds_argument(parser)
+    parser.add_argument(
+        "--lbounds",
+        type=float,
+        nargs="+",
+        required=False,
+        help="Lower bounds of the optimized parameters.",
+    )
+    parser.add_argument(
+        "--ubounds",
+        type=float,
+        nargs="+",
+        required=False,
+        help="Upper bounds of the optimized parameters.",
+    )
     add_delta_ll_argument(parser)
     parser.set_defaults(runner=run_bestfit)
 

--- a/tests/test_BestFit.py
+++ b/tests/test_BestFit.py
@@ -24,9 +24,6 @@ def files():
         [-np.inf, 5, 5, 5, np.inf],
         [-np.inf, 1, 1, 1, np.inf]
         ])
-#     pytest.res = BestFit.get_bestfit_params("./tests/example_data/example.bestfit.two_epoch.demo.params.InferDM.opts.0", 
-#         None, None, "./tests/test_results/not_used", 0.00001)
-# os.remove("./tests/test_results/not_used")
 
 @pytest.mark.skip()
 def test_BestFit(capsys):

--- a/tests/test_BestFit.py
+++ b/tests/test_BestFit.py
@@ -87,8 +87,14 @@ def test_opt_params_converged():
     pass
 
 
-def test_close2boundaries():
-    pass
+@pytest.mark.parametrize("test_type, params, ubounds, lbounds",
+                        [
+                        (False, [10, 10, 10], [15, 15, 15], [1e-3, 1e-3, 1e-3]),
+                        (True, [10, 10, 10], [10.1, 10.1, 10.1,], [1e-3, 1e-3, 1e-3]),
+                         ]
+                         )
+def test_close2boundaries(test_type, params, ubounds, lbounds):
+    assert BestFit.close2boundaries(params, ubounds, lbounds) == test_type
 
 @pytest.mark.parametrize("test_type, ubounds, lbounds",
                         [

--- a/tests/test_BestFit.py
+++ b/tests/test_BestFit.py
@@ -2,6 +2,7 @@ import pytest
 import subprocess
 from dadi_cli import BestFit
 import os
+import numpy as np
 
 try:
     if not os.path.exists("./tests/test_results"):
@@ -18,7 +19,14 @@ def files():
     pytest.example_output = (
         "./tests/test_results/example.bestfit.two_epoch.demo.params.InferDM.bestfits"
     )
-
+    pytest.res = np.array([
+        [-np.inf, 10, 10, 10, np.inf],
+        [-np.inf, 5, 5, 5, np.inf],
+        [-np.inf, 1, 1, 1, np.inf]
+        ])
+#     pytest.res = BestFit.get_bestfit_params("./tests/example_data/example.bestfit.two_epoch.demo.params.InferDM.opts.0", 
+#         None, None, "./tests/test_results/not_used", 0.00001)
+# os.remove("./tests/test_results/not_used")
 
 @pytest.mark.skip()
 def test_BestFit(capsys):
@@ -84,3 +92,31 @@ def test_opt_params_converged():
 
 def test_close2boundaries():
     pass
+
+@pytest.mark.parametrize("test_type, ubounds, lbounds",
+                        [
+                        ("normal_all", [15, 15, 15], [1e-3, 1e-3, 1e-3]),
+                        ("normal_upper", [7, 7, 7], [1e-3, 1e-3, 1e-3]),
+                        ("normal_lower", [15, 15, 15], [3, 3, 3]),
+                        ("bound_error", [15, 15], [1e-3, 1e-3, 1e-3]),
+                        ("res_error", [15, 15], [1e-3, 1e-3]),
+                         ]
+                         )
+def test_boundary_filter(files, test_type, ubounds, lbounds):
+    if "normal" not in test_type:
+        with pytest.raises(ValueError) as exc_info:
+            BestFit.boundary_filter(pytest.res, ubounds, lbounds)
+        assert exc_info.type is ValueError
+        if test_type == "bound_error":
+            assert exc_info.value.args[0]== "Number of upper boundaries do not match number of lower boundaries."
+        if test_type == "res_error":
+            assert exc_info.value.args[0] == "Number of boundaries do not match number of model parameters."
+    else:
+        filtered_res = BestFit.boundary_filter(pytest.res, ubounds, lbounds)
+        if "_all" in test_type:
+            assert np.all(filtered_res == pytest.res)
+        if "_upper" in test_type:
+            assert np.all(filtered_res == pytest.res[1:,:])
+        if "_lower" in test_type:
+            assert np.all(filtered_res == pytest.res[:2,:])
+


### PR DESCRIPTION
Update `dadi_cli.BestFit` with a new function, `boundary_filter`, so only results within the specified boundaries are saved to the ".bestfits" file.

The default behavior will now not require boundaries to make ".bestfits" file.